### PR TITLE
Added CLI approach to specifying Slack API token; #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Make script executable:
 
 ## Usage
 
-You will need a Slack API key. You can get this from the [Slack website](https://api.slack.com/web). The script expects the token to be in a file in the same directory, which will not be checked in to Github. To create it, run the following from the ~/emoji_search directory, subbing in your token and making sure to keep the quotes:
+You will need a Slack API key. You can get this from the [Slack website](https://api.slack.com/web). The script expects the token to be in a file in the same directory, which will not be checked in to GitHub. To create it, run the following from the ~/emoji_search directory, subbing in your token and making sure to keep the quotes:
 
     echo "API_TOKEN = '<MY-API-TOKEN>'" > api_token.py
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ You will need a Slack API key. You can get this from the [Slack website](https:/
 
     echo "API_TOKEN = '<MY-API-TOKEN>'" > api_token.py
 
+Alternatively, you can specify the API key on the commandline with:
+
+    ~/emoji_search/emoji_search.py --api-token=<MY-API-TOKEN> ...
+
 If you did not make the script executable in the optional step above use `python ~/emoji_search/emoji_search.py` in place of `~/emoji_search/emoji_search.py` below:
 
 To query for messages reacted to with the :evergreen_tree: emoji between Nov 2, 2015 and Oct 31, 2015 and write the output to a file called evergreen.txt in the current directory, run:

--- a/emoji_search.py
+++ b/emoji_search.py
@@ -10,8 +10,7 @@ import time
 try:
     from api_token import API_TOKEN
 except ImportError:
-    print('Please store API_TOKEN in api_token.py')
-    sys.exit(1)
+    API_TOKEN = None
 
 MESSAGE_ENDPOINT = 'https://slack.com/api/search.messages'
 USER_ENDPOINT = 'https://slack.com/api/users.info'
@@ -83,7 +82,14 @@ def format_text(text):
               'MM-DD-YYYY format.'), default='01-01-1999')
 @click.option('--enddate', help=('Date to end search. Must be in '
               'MM-DD-YYYY format.'), default='12-12-2222')
-def get_messages(emoji, outfile, startdate, enddate):
+@click.option('--api-token',
+              help=('API Token for querying Slack'),
+              default=None)
+def get_messages(emoji, outfile, startdate, enddate, api_token):
+    if API_TOKEN is None and api_token is None:
+        print('Please store API_TOKEN in api_token.py')
+        sys.exit(1)
+
     if not emoji:
         raise ValueError('Please supply an emoji name to search by')
     print('Querying Slack api')


### PR DESCRIPTION
So I'm not sure that you want / need to keep around the "look for an `api_token.py` file in your Python path with an API_TOKEN value in it" functionality at all, but here I've just added the CLI option for specifying on the command line. Again, can't fully test this without a Slack team / token, but perhaps someone else could check it out and see if it works as expected?
